### PR TITLE
Remove payloads from effector messages

### DIFF
--- a/src/armaf/effector.rs
+++ b/src/armaf/effector.rs
@@ -3,10 +3,10 @@
 use super::{ActorPort, Request};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum EffectorMessage<T> {
-    Execute(T),
-    Rollback(T),
+pub enum EffectorMessage {
+    Execute,
+    Rollback,
 }
 
-pub type EffectorPort<T> = ActorPort<EffectorMessage<T>, (), anyhow::Error>;
-pub type EffectorRequest<T> = Request<EffectorMessage<T>, (), anyhow::Error>;
+pub type EffectorPort = ActorPort<EffectorMessage, (), anyhow::Error>;
+pub type EffectorRequest = Request<EffectorMessage, (), anyhow::Error>;

--- a/src/external/brightness/logind.rs
+++ b/src/external/brightness/logind.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use tokio::fs;
 use tokio::io::AsyncReadExt;
 use zbus;
-use zbus::zvariant::{ObjectPath, OwnedObjectPath};
+use zbus::zvariant::OwnedObjectPath;
 
 /// A [BrightnessController] which uses the kernel's /sys/class/backlight device
 /// class to control the display brightness.

--- a/src/external/brightness/test/mock_test.rs
+++ b/src/external/brightness/test/mock_test.rs
@@ -11,7 +11,7 @@ async fn test_backlight_setting() {
 
 #[tokio::test]
 async fn test_errors() {
-    let mut controller = mock::MockBrightnessController::new(100);
+    let controller = mock::MockBrightnessController::new(100);
     controller.set_failure_mode(true);
     assert!(controller.get_brightness().await.is_err());
     assert!(controller.set_brightness(42).await.is_err());

--- a/src/external/display_server/mock.rs
+++ b/src/external/display_server/mock.rs
@@ -1,6 +1,5 @@
 use super::{DisplayServer, DisplayServerController, SystemState};
 use anyhow::Result;
-use std::cell::RefMut;
 use std::io::{Error, ErrorKind};
 use std::{
     cell::RefCell,

--- a/src/system/display_effector.rs
+++ b/src/system/display_effector.rs
@@ -103,8 +103,8 @@ impl<B: BrightnessController, D: ds::DisplayServerController> DisplayEffector<B,
 }
 
 #[async_trait]
-impl<B: BrightnessController, D: ds::DisplayServerController>
-    Actor<EffectorMessage, ()> for DisplayEffector<B, D>
+impl<B: BrightnessController, D: ds::DisplayServerController> Actor<EffectorMessage, ()>
+    for DisplayEffector<B, D>
 {
     fn get_name(&self) -> String {
         "DisplayEffector".to_owned()

--- a/src/system/idleness_effector.rs
+++ b/src/system/idleness_effector.rs
@@ -1,19 +1,21 @@
 use crate::armaf::{Actor, EffectorMessage};
 use crate::external::display_server::DisplayServerController;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use log;
 
 pub struct IdlenessEffector<C: DisplayServerController> {
+    timeout_sequence: Vec<i16>,
+    current_position: usize,
     controller: C,
-    initial_timeout: i16,
 }
 
 impl<C: DisplayServerController> IdlenessEffector<C> {
-    pub fn new(controller: C) -> IdlenessEffector<C> {
+    pub fn new(controller: C, timeout_sequence: &Vec<i16>) -> IdlenessEffector<C> {
         IdlenessEffector {
+            timeout_sequence: timeout_sequence.clone(),
+            current_position: 0,
             controller,
-            initial_timeout: -1,
         }
     }
 
@@ -26,34 +28,49 @@ impl<C: DisplayServerController> IdlenessEffector<C> {
         let sent_controller = self.controller.clone();
         tokio::task::spawn_blocking(move || sent_controller.set_idleness_timeout(timeout)).await?
     }
+
+    async fn move_in_sequence_by(&mut self, increment: isize) -> Result<()> {
+        let new_position = self.current_position as isize + increment;
+        if new_position > self.timeout_sequence.len() as isize - 1 || new_position < 0 {
+            return Err(anyhow!(
+                "IdlenessController message would cause timeout sequence under/overflow"
+            ));
+        }
+        self.set_timeout(self.timeout_sequence[new_position as usize])
+            .await?;
+        self.current_position = new_position as usize;
+        Ok(())
+    }
 }
 
 #[async_trait]
-impl<C: DisplayServerController> Actor<EffectorMessage<i16>, ()> for IdlenessEffector<C> {
+impl<C: DisplayServerController> Actor<EffectorMessage, ()> for IdlenessEffector<C> {
     fn get_name(&self) -> String {
         "IdlenessEffector".to_owned()
     }
 
-    async fn handle_message(&mut self, payload: EffectorMessage<i16>) -> Result<()> {
-        let timeout_to_set = match payload {
-            EffectorMessage::Execute(timeout) => timeout,
-            EffectorMessage::Rollback(_) => self.initial_timeout,
-        };
-        Ok(self.set_timeout(timeout_to_set).await?)
+    async fn handle_message(&mut self, payload: EffectorMessage) -> Result<()> {
+        match payload {
+            EffectorMessage::Execute => self.move_in_sequence_by(1).await,
+            EffectorMessage::Rollback => self.move_in_sequence_by(-1).await,
+        }
     }
 
     async fn initialize(&mut self) -> Result<()> {
-        self.initial_timeout = match self.get_current_timeout().await {
+        let initial_timeout = match self.get_current_timeout().await {
             Ok(initial_timeout) => initial_timeout,
             Err(err) => {
                 log::error!("Failed getting initial timeout, setting it to -1: {}", err);
                 -1
             }
         };
+        let mut actual_timeout_sequence = vec![initial_timeout];
+        actual_timeout_sequence.extend(self.timeout_sequence.drain(..));
+        self.timeout_sequence = actual_timeout_sequence;
         Ok(())
     }
 
     async fn tear_down(&mut self) -> Result<()> {
-        Ok(self.set_timeout(self.initial_timeout).await?)
+        Ok(self.set_timeout(self.timeout_sequence[0]).await?)
     }
 }

--- a/src/system/inhibition_sensor.rs
+++ b/src/system/inhibition_sensor.rs
@@ -1,9 +1,7 @@
-use crate::armaf::{self, Actor, ActorPort, Request};
+use crate::armaf::{Actor};
 use anyhow::Result;
 use async_trait::async_trait;
-use log;
-use logind_zbus::manager::{self, ManagerProxy};
-use tokio::sync::mpsc::Receiver;
+use logind_zbus::manager::{self};
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct GetInhibitions;
 

--- a/src/system/inhibition_sensor.rs
+++ b/src/system/inhibition_sensor.rs
@@ -1,4 +1,4 @@
-use crate::armaf::{Actor};
+use crate::armaf::Actor;
 use anyhow::Result;
 use async_trait::async_trait;
 use logind_zbus::manager::{self};

--- a/src/system/sleep_effector.rs
+++ b/src/system/sleep_effector.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use std::time::{Duration};
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -24,7 +24,7 @@ impl SleepEffector {
 }
 
 #[async_trait]
-impl Actor<EffectorMessage<()>, ()> for SleepEffector {
+impl Actor<EffectorMessage, ()> for SleepEffector {
     fn get_name(&self) -> String {
         "SleepEffector".to_owned()
     }
@@ -36,13 +36,13 @@ impl Actor<EffectorMessage<()>, ()> for SleepEffector {
         Ok(())
     }
 
-    async fn handle_message(&mut self, payload: EffectorMessage<()>) -> Result<()> {
+    async fn handle_message(&mut self, payload: EffectorMessage) -> Result<()> {
         match payload {
-            EffectorMessage::Execute(()) => {
+            EffectorMessage::Execute => {
                 log::info!("Putting system to sleep");
                 self.manager_proxy.as_ref().unwrap().suspend(false).await?;
             }
-            EffectorMessage::Rollback(()) => {
+            EffectorMessage::Rollback => {
                 loop {
                     let stream_val = self.sleep_signal_stream.as_mut().unwrap().next().await;
                     match stream_val {
@@ -51,6 +51,8 @@ impl Actor<EffectorMessage<()>, ()> for SleepEffector {
                             // The stream may still contain notifications about going to sleep (start = true)
                             // we want to see if we have woken up from sleep.
                             if !signal.args()?.start {
+                                // The signal is sent as the computer is preparing to go to sleep (maybe?)
+                                // We want it to actually go to sleep, thus the wait.
                                 tokio::time::sleep(Duration::from_millis(1000)).await;
                                 return Ok(());
                             } else {

--- a/src/system/sleep_effector.rs
+++ b/src/system/sleep_effector.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration};
+use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;

--- a/src/system/test/display_effector_test.rs
+++ b/src/system/test/display_effector_test.rs
@@ -160,7 +160,6 @@ async fn test_failing_brightness_controller() {
         .await
         .expect_err("No error returned from failing controller");
 
-
     port.request(EffectorMessage::Rollback)
         .await
         .expect_err("Rolling back from initial state succeeded");

--- a/src/system/test/display_effector_test.rs
+++ b/src/system/test/display_effector_test.rs
@@ -5,7 +5,6 @@ use crate::external::brightness::BrightnessController;
 use crate::external::display_server as ds;
 use crate::external::display_server::DisplayServer;
 use crate::external::display_server::DisplayServerController;
-use crate::system::display_effector::DisplayEffect;
 use std::time::Duration;
 
 #[tokio::test]
@@ -27,8 +26,6 @@ async fn test_original_config_saving() {
     .await
     .expect("Actor initialization failed");
 
-    tokio::time::sleep(Duration::from_millis(250)).await;
-
     // Test if the display effector sets its own state when it's initialized
     assert_eq!(
         ds_controller.get_dpms_level().unwrap(),
@@ -43,7 +40,7 @@ async fn test_original_config_saving() {
     // termination if it wasn't changed by itself
     brightness.set_brightness(45).await.unwrap();
 
-    // Test if the display effector resets the state to original when it's initialized
+    // Test if the display effector resets the state to original when it's terminated
     drop(port);
     assert_eq!(
         ds_controller.get_dpms_level().unwrap(),
@@ -68,12 +65,12 @@ async fn test_basic_flow() {
     ))
     .await
     .expect("Actor initialization failed");
-    port.request(EffectorMessage::Execute(DisplayEffect::Dim))
+    port.request(EffectorMessage::Execute)
         .await
         .expect("Failed to dim display");
     assert_eq!(brightness.get_brightness().await.unwrap(), 40);
 
-    port.request(EffectorMessage::Execute(DisplayEffect::TurnOff))
+    port.request(EffectorMessage::Execute)
         .await
         .expect("Failed to turn display off");
     assert_eq!(
@@ -81,7 +78,7 @@ async fn test_basic_flow() {
         Some(ds::DPMSLevel::Off)
     );
 
-    port.request(EffectorMessage::Rollback(DisplayEffect::TurnOff))
+    port.request(EffectorMessage::Rollback)
         .await
         .expect("Failed to turn display on");
     assert_eq!(
@@ -90,7 +87,7 @@ async fn test_basic_flow() {
     );
     assert_eq!(brightness.get_brightness().await.unwrap(), 40);
 
-    port.request(EffectorMessage::Rollback(DisplayEffect::Dim))
+    port.request(EffectorMessage::Rollback)
         .await
         .expect("Failed to undim display");
     assert_eq!(brightness.get_brightness().await.unwrap(), 80);
@@ -107,7 +104,7 @@ async fn test_undim_on_termination() {
     ))
     .await
     .expect("Actor initialization failed");
-    port.request(EffectorMessage::Execute(DisplayEffect::Dim))
+    port.request(EffectorMessage::Execute)
         .await
         .expect("Failed to dim display");
     assert_eq!(brightness.get_brightness().await.unwrap(), 40);
@@ -131,19 +128,16 @@ async fn test_failing_display_server() {
 
     display.set_failure_mode(true);
 
-    port.request(EffectorMessage::Execute(DisplayEffect::Dim))
+    port.request(EffectorMessage::Execute)
         .await
         .expect("Failed to dim display");
     assert_eq!(brightness.get_brightness().await.unwrap(), 40);
 
-    port.request(EffectorMessage::Execute(DisplayEffect::TurnOff))
-        .await
-        .expect_err("No error reported on failing display server controller");
-    port.request(EffectorMessage::Rollback(DisplayEffect::TurnOff))
+    port.request(EffectorMessage::Execute)
         .await
         .expect_err("No error reported on failing display server controller");
 
-    port.request(EffectorMessage::Rollback(DisplayEffect::Dim))
+    port.request(EffectorMessage::Rollback)
         .await
         .expect("Failed to undim display");
     assert_eq!(brightness.get_brightness().await.unwrap(), 80);
@@ -153,7 +147,6 @@ async fn test_failing_display_server() {
 async fn test_failing_brightness_controller() {
     let brightness = bs::mock::MockBrightnessController::new(80);
     let display = ds::mock::Interface::new(-1);
-    let ds_controller = display.get_controller();
     let port = spawn_actor(display_effector::DisplayEffector::new(
         brightness.clone(),
         display.get_controller(),
@@ -163,37 +156,22 @@ async fn test_failing_brightness_controller() {
 
     brightness.set_failure_mode(true);
 
-    port.request(EffectorMessage::Execute(DisplayEffect::Dim))
+    port.request(EffectorMessage::Execute)
         .await
         .expect_err("No error returned from failing controller");
 
-    port.request(EffectorMessage::Execute(DisplayEffect::TurnOff))
-        .await
-        .expect("Failed to turn display off");
-    assert_eq!(
-        ds_controller.get_dpms_level().unwrap(),
-        Some(ds::DPMSLevel::Off)
-    );
 
-    port.request(EffectorMessage::Rollback(DisplayEffect::TurnOff))
+    port.request(EffectorMessage::Rollback)
         .await
-        .expect("Failed to turn display on");
-    assert_eq!(
-        ds_controller.get_dpms_level().unwrap(),
-        Some(ds::DPMSLevel::On)
-    );
-
-    port.request(EffectorMessage::Rollback(DisplayEffect::Dim))
-        .await
-        .expect_err("An error should be returned from undim if no dimming occurred");
+        .expect_err("Rolling back from initial state succeeded");
 
     brightness.set_failure_mode(false);
-    port.request(EffectorMessage::Execute(DisplayEffect::Dim))
+    port.request(EffectorMessage::Execute)
         .await
         .expect("Dimming failed");
     assert_eq!(brightness.get_brightness().await.unwrap(), 40);
     brightness.set_failure_mode(true);
-    port.request(EffectorMessage::Rollback(DisplayEffect::Dim))
+    port.request(EffectorMessage::Rollback)
         .await
         .expect_err("No error occurred even when undim failed");
 }

--- a/src/system/test/idleness_effector_test.rs
+++ b/src/system/test/idleness_effector_test.rs
@@ -7,19 +7,40 @@ use tokio;
 async fn test_happy_path() {
     let iface = mock::Interface::new(600);
     let setter = iface.get_controller();
+    let sequence = vec![10, 20, 30];
     let port = spawn_actor(idleness_effector::IdlenessEffector::new(
         iface.get_controller(),
+        &sequence
     ))
     .await
     .expect("Actor initialization failed");
-    port.request(EffectorMessage::Execute(10))
+    for timeout in sequence.iter() {
+        port.request(EffectorMessage::Execute)
         .await
         .expect("Idleness effector failed to set idleness");
-    assert_eq!(setter.get_idleness_timeout().unwrap(), 10);
-    port.request(EffectorMessage::Rollback(1))
+        assert_eq!(setter.get_idleness_timeout().unwrap(), *timeout);
+    }
+
+    port.request(EffectorMessage::Execute)
         .await
-        .expect("Idleness effector failed to roll back");
-    assert_eq!(setter.get_idleness_timeout().unwrap(), 600);
+        .expect_err("Idleness effector overflowed timeout sequence");
+    
+    for i in 1..sequence.len() {
+        port.request(EffectorMessage::Rollback)
+            .await
+            .expect("Idleness effector failed to roll back");
+        assert_eq!(setter.get_idleness_timeout().unwrap(), sequence[sequence.len() - 1 - i]);
+    }
+
+    port.request(EffectorMessage::Rollback)
+            .await
+            .expect("Idleness effector failed to roll back");
+        assert_eq!(setter.get_idleness_timeout().unwrap(), 600);
+    
+        port.request(EffectorMessage::Rollback)
+        .await
+        .expect_err("Idleness effector underflowed timeout sequence");
+    
     drop(port);
 }
 
@@ -30,17 +51,24 @@ async fn test_error_handling() {
     let setter = iface.get_controller();
     let port = spawn_actor(idleness_effector::IdlenessEffector::new(
         iface.get_controller(),
+        &vec![20, 30]
     ))
     .await
     .expect("Actor initialization failed");
-    port.request(EffectorMessage::Execute(10))
-        .await
-        .expect_err("Idleness effector didn't return an error on broken interface");
-    port.request(EffectorMessage::Rollback(1))
+    port.request(EffectorMessage::Execute)
         .await
         .expect_err("Idleness effector didn't return an error on broken interface");
     iface.set_failure_mode(false);
-    port.request(EffectorMessage::Rollback(1))
+    port.request(EffectorMessage::Execute)
+        .await
+        .expect("Idleness effector failed to set idleness");
+    assert_eq!(setter.get_idleness_timeout().unwrap(), 20);
+    iface.set_failure_mode(true);
+    port.request(EffectorMessage::Rollback)
+        .await
+        .expect_err("Idleness effector didn't return an error on broken interface");
+    iface.set_failure_mode(false);
+    port.request(EffectorMessage::Rollback)
         .await
         .expect("Idleness effector failed to roll back");
     assert_eq!(setter.get_idleness_timeout().unwrap(), -1);

--- a/src/system/test/idleness_effector_test.rs
+++ b/src/system/test/idleness_effector_test.rs
@@ -10,37 +10,40 @@ async fn test_happy_path() {
     let sequence = vec![10, 20, 30];
     let port = spawn_actor(idleness_effector::IdlenessEffector::new(
         iface.get_controller(),
-        &sequence
+        &sequence,
     ))
     .await
     .expect("Actor initialization failed");
     for timeout in sequence.iter() {
         port.request(EffectorMessage::Execute)
-        .await
-        .expect("Idleness effector failed to set idleness");
+            .await
+            .expect("Idleness effector failed to set idleness");
         assert_eq!(setter.get_idleness_timeout().unwrap(), *timeout);
     }
 
     port.request(EffectorMessage::Execute)
         .await
         .expect_err("Idleness effector overflowed timeout sequence");
-    
+
     for i in 1..sequence.len() {
         port.request(EffectorMessage::Rollback)
             .await
             .expect("Idleness effector failed to roll back");
-        assert_eq!(setter.get_idleness_timeout().unwrap(), sequence[sequence.len() - 1 - i]);
+        assert_eq!(
+            setter.get_idleness_timeout().unwrap(),
+            sequence[sequence.len() - 1 - i]
+        );
     }
 
     port.request(EffectorMessage::Rollback)
-            .await
-            .expect("Idleness effector failed to roll back");
-        assert_eq!(setter.get_idleness_timeout().unwrap(), 600);
-    
-        port.request(EffectorMessage::Rollback)
+        .await
+        .expect("Idleness effector failed to roll back");
+    assert_eq!(setter.get_idleness_timeout().unwrap(), 600);
+
+    port.request(EffectorMessage::Rollback)
         .await
         .expect_err("Idleness effector underflowed timeout sequence");
-    
+
     drop(port);
 }
 
@@ -51,7 +54,7 @@ async fn test_error_handling() {
     let setter = iface.get_controller();
     let port = spawn_actor(idleness_effector::IdlenessEffector::new(
         iface.get_controller(),
-        &vec![20, 30]
+        &vec![20, 30],
     ))
     .await
     .expect("Actor initialization failed");

--- a/src/system/test/sleep_effector_test.rs
+++ b/src/system/test/sleep_effector_test.rs
@@ -21,12 +21,12 @@ async fn test_idle_hints() {
     ))
     .await
     .expect("Failed to start actor");
-    port.request(EffectorMessage::Execute(()))
+    port.request(EffectorMessage::Execute)
         .await
         .expect("Failed to put computer to sleep");
     // Instant:: is a sythetic monotonic clock - it stops in sleep, so it will always just give you 5 seconds
     let start = SystemTime::now();
-    port.request(EffectorMessage::Rollback(()))
+    port.request(EffectorMessage::Rollback)
         .await
         .expect("Failed to put computer to sleep");
     let elapsed_time = start.elapsed().unwrap();

--- a/src/system/test/sleep_effector_test.rs
+++ b/src/system/test/sleep_effector_test.rs
@@ -9,27 +9,28 @@ use crate::{
 
 // This is indeed not a true test. It's a bit difficult to test behavior which
 // actually causes the computer to go down.
-// If you want to test if the functionality didn't break, just run it manually.
-#[tokio::test]
-#[ignore]
-async fn test_idle_hints() {
-    env::set_var("RUST_LOG", "debug");
-    env_logger::init();
-    let mut factory = dbus::ConnectionFactory::new();
-    let port = spawn_actor(sleep_effector::SleepEffector::new(
-        factory.get_system().await.unwrap(),
-    ))
-    .await
-    .expect("Failed to start actor");
-    port.request(EffectorMessage::Execute)
-        .await
-        .expect("Failed to put computer to sleep");
-    // Instant:: is a sythetic monotonic clock - it stops in sleep, so it will always just give you 5 seconds
-    let start = SystemTime::now();
-    port.request(EffectorMessage::Rollback)
-        .await
-        .expect("Failed to put computer to sleep");
-    let elapsed_time = start.elapsed().unwrap();
-    log::debug!("Rollback done after {}ms", elapsed_time.as_millis());
-    assert!(elapsed_time.as_secs() > 10);
-}
+// If you want to test if the functionality didn't break, just uncomment it,
+// run it manually and keep the computer asleep for at least 10 seconds.
+// #[tokio::test]
+// #[ignore]
+// async fn test_idle_hints() {
+//     env::set_var("RUST_LOG", "debug");
+//     env_logger::init();
+//     let mut factory = dbus::ConnectionFactory::new();
+//     let port = spawn_actor(sleep_effector::SleepEffector::new(
+//         factory.get_system().await.unwrap(),
+//     ))
+//     .await
+//     .expect("Failed to start actor");
+//     port.request(EffectorMessage::Execute)
+//         .await
+//         .expect("Failed to put computer to sleep");
+//     // Instant:: is a sythetic monotonic clock - it stops in sleep, so it will always just give you 5 seconds
+//     let start = SystemTime::now();
+//     port.request(EffectorMessage::Rollback)
+//         .await
+//         .expect("Failed to put computer to sleep");
+//     let elapsed_time = start.elapsed().unwrap();
+//     log::debug!("Rollback done after {}ms", elapsed_time.as_millis());
+//     assert!(elapsed_time.as_secs() > 10);
+// }


### PR DESCRIPTION
As a preparation for controller implementation, we want effectors to keep their internal state instead of being completely externally driven. 
To enforce that, payloads from effector messages were removed.