### PR TITLE
Graceful termination changes

### DIFF
--- a/src/armaf/ports.rs
+++ b/src/armaf/ports.rs
@@ -145,7 +145,7 @@ impl<P, R, E: Debug> ActorPort<P, R, E> {
         }
     }
 
-    /// Await actor' termination
+    /// Await actor termination
     /// 
     /// Drops this port's message sender and waits until all the other clones of
     /// this ActorPort are dropped or have this method called and the actor

--- a/src/armaf/ports.rs
+++ b/src/armaf/ports.rs
@@ -229,9 +229,20 @@ impl Handle {
     }
 }
 
+/// The side of the handle belonging to the child actor.
+///
+/// This struct can be used to check whether the parent actor requested the
+/// actor to terminate. Since it's based on [ActorPort], same caveats apply - it
+/// should never be dropped during actor operation or while clean up is still
+/// pending.
 pub struct HandleChild(ActorReceiver<(), (), ()>);
 
 impl HandleChild {
+    /// Wait until the parent [Handle] is dropped or its
+    /// [await_shutdown](`Handle::await_shutdown`) method is called.
+    ///
+    /// Since this function will not return until these conditions are
+    /// fulfilled, you should call it within a [tokio::select!] block.
     pub async fn should_terminate(&mut self) {
         let res = self.0.recv().await;
         assert!(res.is_none());

--- a/src/armaf/test_ports.rs
+++ b/src/armaf/test_ports.rs
@@ -1,5 +1,5 @@
 use super::ports;
-use std::sync::{Arc, atomic::AtomicBool};
+use std::sync::{atomic::AtomicBool, Arc};
 use tokio;
 
 #[tokio::test]
@@ -43,16 +43,22 @@ async fn test_actor_port() {
     } else {
         panic!("An error from Actor is not translated correctly");
     }
-    assert!(!termination_flag.as_ref().load(std::sync::atomic::Ordering::Acquire));
+    assert!(!termination_flag
+        .as_ref()
+        .load(std::sync::atomic::Ordering::Acquire));
     port.await_shutdown().await;
-    assert!(termination_flag.as_ref().load(std::sync::atomic::Ordering::Acquire));
+    assert!(termination_flag
+        .as_ref()
+        .load(std::sync::atomic::Ordering::Acquire));
 }
 
 #[tokio::test]
 async fn test_request_errors() {
     let termination_flag = make_termination_flag();
     let port = spawn_two_increments_one_error(termination_flag.clone());
-    assert!(!termination_flag.as_ref().load(std::sync::atomic::Ordering::Acquire));
+    assert!(!termination_flag
+        .as_ref()
+        .load(std::sync::atomic::Ordering::Acquire));
     let recv_error = port
         .request(TestActorMessage::Terminate)
         .await
@@ -81,7 +87,9 @@ enum TestActorMessage {
     Terminate,
 }
 
-fn spawn_two_increments_one_error(termination_flag: Arc<AtomicBool>) -> ports::ActorPort<TestActorMessage, usize, std::io::Error> {
+fn spawn_two_increments_one_error(
+    termination_flag: Arc<AtomicBool>,
+) -> ports::ActorPort<TestActorMessage, usize, std::io::Error> {
     let (port, mut rx) = ports::ActorPort::make();
     tokio::spawn(async move {
         let mut count = 0;
@@ -106,18 +114,43 @@ fn spawn_two_increments_one_error(termination_flag: Arc<AtomicBool>) -> ports::A
                 TestActorMessage::Terminate => return,
             }
         }
-        termination_flag.as_ref().store(true, std::sync::atomic::Ordering::Release);
+        termination_flag
+            .as_ref()
+            .store(true, std::sync::atomic::Ordering::Release);
     });
     port
 }
 
-fn make_termination_flag() -> Arc<AtomicBool> {
-    Arc::new(AtomicBool::new(false))
+#[tokio::test]
+async fn test_handle_drop() {
+    let flag = make_termination_flag();
+    let handle = spawn_handle_tester(flag.clone());
+    assert!(!flag.as_ref().load(std::sync::atomic::Ordering::Acquire));
+    drop(handle);
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    assert!(flag.as_ref().load(std::sync::atomic::Ordering::Acquire));
 }
 
-#[test]
-fn test_handle_creation() {
-    let (handle, receiver) = ports::Handle::new();
-    drop(handle);
-    assert!(receiver.blocking_recv().is_err());
+#[tokio::test]
+async fn test_handle_await() {
+    let flag = make_termination_flag();
+    let handle = spawn_handle_tester(flag.clone());
+    assert!(!flag.as_ref().load(std::sync::atomic::Ordering::Acquire));
+    handle.await_shutdown().await;
+    assert!(flag.as_ref().load(std::sync::atomic::Ordering::Acquire));
+}
+
+fn spawn_handle_tester(termination_flag: Arc<AtomicBool>) -> ports::Handle {
+    let (handle, mut handle_child) = ports::Handle::new();
+    tokio::spawn(async move {
+        handle_child.should_terminate().await;
+        termination_flag
+            .as_ref()
+            .store(true, std::sync::atomic::Ordering::Release);
+    });
+    handle
+}
+
+fn make_termination_flag() -> Arc<AtomicBool> {
+    Arc::new(AtomicBool::new(false))
 }

--- a/src/armaf/test_server.rs
+++ b/src/armaf/test_server.rs
@@ -59,7 +59,7 @@ async fn test_happy_path() {
     let port = spawn_server(server).await.expect("No port returned");
     assert_eq!(port.request(()).await.unwrap(), 1);
     assert_eq!(port.request(()).await.unwrap(), 2);
-    drop(port);
+    port.await_shutdown().await;
     notifier
         .recv()
         .await
@@ -73,7 +73,7 @@ async fn test_response_failure() {
     assert_eq!(port.request(()).await.unwrap(), 1);
     assert_eq!(port.request(()).await.unwrap(), 2);
     assert!(port.request(()).await.is_err());
-    drop(port);
+    drop(port); // tear_down should be called 
     notifier
         .recv()
         .await

--- a/src/armaf/test_server.rs
+++ b/src/armaf/test_server.rs
@@ -73,7 +73,7 @@ async fn test_response_failure() {
     assert_eq!(port.request(()).await.unwrap(), 1);
     assert_eq!(port.request(()).await.unwrap(), 2);
     assert!(port.request(()).await.is_err());
-    drop(port); // tear_down should be called 
+    drop(port); // tear_down should be called
     notifier
         .recv()
         .await

--- a/src/control/environment_controller.rs
+++ b/src/control/environment_controller.rs
@@ -96,12 +96,14 @@ impl<B: BrightnessController, D: DisplayServer> EnvironmentController<B, D> {
             let sequencer_handle = sequencer.spawn().await?;
             tokio::select! {
                 _ = self.handle_child.as_mut().unwrap().should_terminate() => {
+                    sequencer_handle.await_shutdown().await;
                     log::info!("Handle dropped, terminating");
                     return Ok(());
                 }
-                _ = self.power_source_receiver.changed() => {}
+                _ = self.power_source_receiver.changed() => {
+                    sequencer_handle.await_shutdown().await;
+                }
             }
-            sequencer_handle.await_shutdown().await;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,9 @@ use crate::system::upower_sensor::UPowerSensor;
 
 #[tokio::main]
 async fn main() {
-    env::set_var("RUST_LOG", "trace");
+    if env::var("RUST_LOG").is_err() {
+        env::set_var("RUST_LOG", "debug");
+    }
     env_logger::init();
     let config_bytes = fs::read("config.toml")
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,6 @@ async fn main() {
             .expect("Couldn't construct environment controller");
     let handle = environment_controller.spawn().await;
     tokio::signal::ctrl_c().await.expect("Signal wait failed");
-    drop(handle);
+    handle.await_shutdown().await;
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 }

--- a/src/system/test/display_effector_test.rs
+++ b/src/system/test/display_effector_test.rs
@@ -44,14 +44,14 @@ async fn test_original_config_saving() {
     brightness.set_brightness(45).await.unwrap();
 
     // Test if the display effector resets the state to original when it's terminated
-    drop(port);
+    port.await_shutdown().await;
     assert_eq!(
         ds_controller.get_dpms_level().unwrap(),
-        Some(ds::DPMSLevel::On)
+        Some(ds::DPMSLevel::Standby)
     );
     assert_eq!(
         ds_controller.get_dpms_timeouts().unwrap(),
-        ds::DPMSTimeouts::new(0, 0, 0)
+        ds::DPMSTimeouts::new(42, 43, 44)
     );
     assert_eq!(brightness.get_brightness().await.unwrap(), 45);
 }
@@ -111,7 +111,7 @@ async fn test_undim_on_termination() {
         .await
         .expect("Failed to dim display");
     assert_eq!(brightness.get_brightness().await.unwrap(), 40);
-    drop(port);
+    port.await_shutdown().await;
     tokio::time::sleep(Duration::from_millis(250)).await;
     assert_eq!(brightness.get_brightness().await.unwrap(), 80);
 }

--- a/src/system/test/sequencer_test.rs
+++ b/src/system/test/sequencer_test.rs
@@ -45,6 +45,7 @@ async fn test_complete_sequence() {
     sleep(Duration::from_secs(1)).await;
     assert!(receiver.request_receiver.try_recv().is_err());
 
+    drop(receiver);
     handle.await_shutdown().await;
     assert_eq!(iface.get_controller().get_idleness_timeout().unwrap(), 600);
 }
@@ -94,8 +95,8 @@ async fn test_interruptions() {
         .unwrap();
     assert_request_came(&mut receiver, SystemState::Awakened, Ok(())).await;
 
-    drop(handle);
-    sleep(Duration::from_millis(100)).await;
+    drop(receiver);
+    handle.await_shutdown().await;
     assert_eq!(iface.get_controller().get_idleness_timeout().unwrap(), 600);
 }
 
@@ -153,8 +154,8 @@ async fn test_actor_errors() {
     assert_request_came(&mut receiver, SystemState::Awakened, Ok(())).await;
     assert!(receiver.request_receiver.try_recv().is_err());
 
-    drop(handle);
-    sleep(Duration::from_millis(100)).await;
+    drop(receiver);
+    handle.await_shutdown().await;
     assert_eq!(iface.get_controller().get_idleness_timeout().unwrap(), 600);
 }
 

--- a/src/system/test/sequencer_test.rs
+++ b/src/system/test/sequencer_test.rs
@@ -25,25 +25,25 @@ async fn test_complete_sequence() {
         .spawn()
         .await
         .expect("Sequencer failed to initialize");
-    assert!(receiver.try_recv().is_err());
+    assert!(receiver.request_receiver.try_recv().is_err());
 
     assert_eq!(iface.get_controller().get_idleness_timeout().unwrap(), 5);
 
     iface.notify_state_transition(SystemState::Idle).unwrap();
     assert_request_came(&mut receiver, SystemState::Idle, Ok(())).await;
 
-    assert!(receiver.try_recv().is_err());
+    assert!(receiver.request_receiver.try_recv().is_err());
     sleep(Duration::from_secs(6)).await;
 
     assert_request_came(&mut receiver, SystemState::Idle, Ok(())).await;
 
-    assert!(receiver.try_recv().is_err());
+    assert!(receiver.request_receiver.try_recv().is_err());
     sleep(Duration::from_secs(3)).await;
 
     assert_request_came(&mut receiver, SystemState::Idle, Ok(())).await;
 
     sleep(Duration::from_secs(1)).await;
-    assert!(receiver.try_recv().is_err());
+    assert!(receiver.request_receiver.try_recv().is_err());
 
     drop(handle);
     sleep(Duration::from_millis(100)).await;
@@ -126,7 +126,7 @@ async fn test_actor_errors() {
     )
     .await;
 
-    assert!(receiver.try_recv().is_err());
+    assert!(receiver.request_receiver.try_recv().is_err());
     sleep(Duration::from_millis(200)).await;
     iface.notify_state_transition(SystemState::Idle).unwrap();
     assert_request_came(&mut receiver, SystemState::Idle, Ok(())).await;
@@ -152,7 +152,7 @@ async fn test_actor_errors() {
         .notify_state_transition(SystemState::Awakened)
         .unwrap();
     assert_request_came(&mut receiver, SystemState::Awakened, Ok(())).await;
-    assert!(receiver.try_recv().is_err());
+    assert!(receiver.request_receiver.try_recv().is_err());
 
     drop(handle);
     sleep(Duration::from_millis(100)).await;
@@ -160,7 +160,7 @@ async fn test_actor_errors() {
 }
 
 async fn assert_request_came(
-    receiver: &mut mpsc::Receiver<armaf::Request<SystemState, (), anyhow::Error>>,
+    receiver: &mut armaf::ActorReceiver<SystemState, (), anyhow::Error>,
     expected_state: SystemState,
     response: Result<()>,
 ) {

--- a/src/system/test/sequencer_test.rs
+++ b/src/system/test/sequencer_test.rs
@@ -6,7 +6,7 @@ use crate::{
     system::sequencer::Sequencer,
 };
 use anyhow::{anyhow, Result};
-use tokio::{self, sync::mpsc, time::sleep};
+use tokio::{self, time::sleep};
 
 #[tokio::test]
 async fn test_complete_sequence() {
@@ -45,8 +45,7 @@ async fn test_complete_sequence() {
     sleep(Duration::from_secs(1)).await;
     assert!(receiver.request_receiver.try_recv().is_err());
 
-    drop(handle);
-    sleep(Duration::from_millis(100)).await;
+    handle.await_shutdown().await;
     assert_eq!(iface.get_controller().get_idleness_timeout().unwrap(), 600);
 }
 


### PR DESCRIPTION
Currently, there is no way to wait for actors to terminate, so we're just relying on tokio::sleeps and blind luck. That's not sustainable and is already causing bugs. This MR:

- Implements termination signalization and waits to `ActorPort`s
- Refactors `Handle` to allow to wait on termination, based on the new `ActorPort` functionality
- Implements termination waits in all the relevant controllers